### PR TITLE
feat: adjust insertion of location_types

### DIFF
--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -445,12 +445,8 @@ insert into transfer_types (transfer_type, description) VALUES
   (2,'Transfer possible with min_transfer_time window'),
   (3,'Transfers forbidden');
 
-insert into location_types(location_type, description) values 
-  (0,'stop'),
-  (1,'station'),
-  (2,'station entrance'),
-  (3,'generic node'),
-  (4,'boarding area');
+INSERT INTO location_types(location_type,description)
+VALUES (0,'stops'),(1,'station'),(2,'station entrance'),(3,'generic node'),(4,'boarding area');
 
 insert into wheelchair_boardings(wheelchair_boarding, description) values
    (0, 'No accessibility information available for the stop'),


### PR DESCRIPTION
Hi folks,
I do not know why jet, but the current master branch creates the table `location_types` like this

```
=> select * from gtfs.location_types;
 location_type |   description    
---------------+------------------
             0 | stop
             1 | station
             2 | station entrance
(3 rows)
```

and this pull request in comparison creates the table `location_types` like this.

```=> select * from gtfs.location_types;
 location_type |   description    
---------------+------------------
             0 | stops
             1 | station
             2 | station entrance
             3 | generic node
             4 | boarding area
(5 rows)
```

As a consequence, two location types are missing when using the current master branch.

Who has an idea about the reason?

Please feel free to improve, study, share or use this pull request. Cheers!